### PR TITLE
Do not reset error counter before each test

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -415,12 +415,14 @@ run_ptests(struct ptest_list *head, const struct ptest_options opts,
 			int pipefd_stderr[2] = {-1, -1};
 			int pgid = -1;
 
-			if ((rc = pipe2(pipefd_stdout, 0)) == -1)
+			if (pipe2(pipefd_stdout, 0) == -1) {
+				rc = -1;
 				break;
-
-			if ((rc = pipe2(pipefd_stderr, 0)) == -1) {
+			}
+			if (pipe2(pipefd_stderr, 0) == -1) {
 				close(pipefd_stdout[PIPE_READ]);
 				close(pipefd_stdout[PIPE_WRITE]);
+				rc = -1;
 				break;
 			}
 


### PR DESCRIPTION
Commit 56ed1082c4914c0ef3c72bfd609d68cc850557f1 moved the pipe-creation into the loop and reseted rc before each test, such that only the result code of the last test was taken into account for the final verdict.

Only set rc = -1 if pipe() fails to keep collected test-errors.